### PR TITLE
Switch to openjdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 before_script:
   - echo $PWD


### PR DESCRIPTION
https://www.travis-ci.org/gwenn/sqlite-jna/builds/565612139
> The command "~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"" failed and exited with 3 during .